### PR TITLE
Revert use real random port allocation

### DIFF
--- a/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManager.java
+++ b/src/main/java/org/jvnet/hudson/plugins/port_allocator/PortAllocationManager.java
@@ -7,7 +7,6 @@ import hudson.remoting.Callable;
 import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.net.ServerSocket;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
@@ -25,8 +24,6 @@ public final class PortAllocationManager {
 
     /** Maximum number of tries to allocate a specific port range. */
     private static final int MAX_TRIES = 100;
-    private static final int RANDOM_PORT_MIN = 10000;
-    private static final int RANDOM_PORT_MAX = 65000;
 
     /**
      * Ports currently in use, to the build that uses it.
@@ -55,18 +52,11 @@ public final class PortAllocationManager {
     public synchronized int allocateRandom(AbstractBuild owner, int prefPort) throws InterruptedException, IOException {
         int i;
         try {
-            // First try to allocate a completely random port, even if there is a prefered one.
-            // This should fix issues with duplicated port allocation if using this plugin with lots of builds
-            // at the same time.
-            i = allocatePort(ThreadLocalRandom.current().nextInt(RANDOM_PORT_MIN, RANDOM_PORT_MAX + 1));
+            // try to allocate preferential port,
+            i = allocatePort(prefPort);
         } catch (PortUnavailableException ex) {
-            try {
-                // try to allocate preferential port,
-                i = allocatePort(prefPort);
-            } catch (PortUnavailableException ex2) {
-                // if not available, assign a random port
-                i = allocatePort(0);
-            }
+            // if not available, assign a random port
+            i = allocatePort(0);
         }
         ports.put(i,owner);
         return i;


### PR DESCRIPTION
Does not work as expected.

Returned always the same port:
- https://jenkins.4teamwork.ch/job/gever-ui-test-e2e-master-1.cfg/1759/console
- https://jenkins.4teamwork.ch/job/gever-ui-test-e2e-master-2.cfg/1700/console
- https://jenkins.4teamwork.ch/job/gever-ui-test-e2e-master-3.cfg/1805/console

Reverts #4 
